### PR TITLE
fix JP link not being clickable on mobile and small windows

### DIFF
--- a/css.css
+++ b/css.css
@@ -1475,6 +1475,7 @@ blockquote p {
       font-size:16px;
       top:0;
       right:0;
+      z-index: 1000;
     }
 
     .gap{


### PR DESCRIPTION
didn't test mobile browsers when I was making the JP version, so didn't notice that this link wasn't clickable. fixed now.